### PR TITLE
Proxy configuration - Do not activate proxy for 'No Proxy Host"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .settings
 bin
 work
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.567</version>
+        <version>1.579</version>
     </parent>
 
     <artifactId>mattermost</artifactId>
@@ -53,6 +53,11 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20131018</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/webapp/help-globalConfig-mattermostEndpoint.html
+++ b/src/main/webapp/help-globalConfig-mattermostEndpoint.html
@@ -2,4 +2,5 @@
 	<p>Your Mattermost incoming webhook url.</p>
 	<p>It is possible to override this setting per project.</p>
 	<p>See <a href="http://www.mattermost.org/webhooks/">documentation</a></p>
+    <p>Note: the plugin uses the HTTP Proxy Configuration set in Plugin Manager. Fill the 'No Proxy Host' field if your Mattermost instance is hosted internally.</p>
 </div>

--- a/src/main/webapp/help-projectConfig-mattermostEndpoint.html
+++ b/src/main/webapp/help-projectConfig-mattermostEndpoint.html
@@ -2,4 +2,5 @@
 	<p>Your Mattermost incoming webhook url.</p>
 	<p>This overrides the global setting.</p>
 	<p>See <a href="http://www.mattermost.org/webhooks/">documentation</a></p>
+    <p>Note: the plugin uses the HTTP Proxy Configuration set in Plugin Manager. Fill the 'No Proxy Host' field if your Mattermost instance is hosted internally.</p>
 </div>

--- a/src/test/java/jenkins/plugins/mattermost/StandardMattermostServiceTest.java
+++ b/src/test/java/jenkins/plugins/mattermost/StandardMattermostServiceTest.java
@@ -1,11 +1,13 @@
 package jenkins.plugins.mattermost;
 
+import hudson.ProxyConfiguration;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
 
 public class StandardMattermostServiceTest {
 
@@ -91,4 +93,30 @@ public class StandardMattermostServiceTest {
         service.setHttpClient(httpClientStub);
         assertTrue(service.publish("message"));
     }
+
+    @Test
+    public void isProxyRequiredEmtyNoProxyHostsReturnsTrue() {
+        StandardMattermostService service = new StandardMattermostService("http://mymattermost.endpoint.com","roomid","icon");
+        assertTrue(service.isProxyRequired(Collections.<Pattern>emptyList()));
+    }
+
+    @Test
+    public void isProxyRequiredNoProxyHostsDoesNotMatchReturnsTrue() {
+        StandardMattermostService service = new StandardMattermostService("http://mymattermost.endpoint.com","roomid","icon");
+        assertTrue(service.isProxyRequired(ProxyConfiguration.getNoProxyHostPatterns("*.internal.com")));
+    }
+
+    @Test
+    public void isProxyRequiredNoProxyHostsMatchReturnsFalse() {
+        StandardMattermostService service = new StandardMattermostService("http://mymattermost.endpoint.com","roomid","icon");
+        assertFalse(service.isProxyRequired(ProxyConfiguration.getNoProxyHostPatterns("*.endpoint.com")));
+    }
+
+    @Test
+    public void isProxyRequiredInvalidEndPointReturnsTrue() {
+        StandardMattermostService service = new StandardMattermostService("htt://mymattermost.endpoint.com","roomid","icon");
+        assertTrue(service.isProxyRequired(ProxyConfiguration.getNoProxyHostPatterns("*.internal.com")));
+    }
+
+
 }


### PR DESCRIPTION
Hello, 

The plugin uses Proxy defined in Jenkins Plugin Manager settings.
This PR checks if the Mattermost endpoint is defined in 'No Proxy Host' field before activating the proxy.
