### PR TITLE
Don't include the channel in the request if the field is empty

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/StandardMattermostService.java
+++ b/src/main/java/jenkins/plugins/mattermost/StandardMattermostService.java
@@ -51,7 +51,7 @@ public class StandardMattermostService implements MattermostService {
 			JSONObject json = new JSONObject();
 
 			try {
-				json.put("channel", roomId);
+				if (!roomId.isEmpty()) json.put("channel", roomId);
 				json.put("text", message);
 				json.put("username", "jenkins");
 				json.put("icon_url", icon);


### PR DESCRIPTION
Hi. I made this little change to solve a problem that I had in my company by integrating  Mattermos with Jenkins. We want to make the request to the endpoint without specifying a channel, but if we let the field empty in the configuration, the channel is sent in the payload as "channel": "", and the request fails. I hope you find it useful, regards.
