### PR TITLE
Declare the workflow-step-api dependency as optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
This dependency is only necessary for MattermostSendStep. By making it optional, the Mattermost plugin can be used on Jenkins servers that do not have the pipeline plugins installed.