### PR TITLE
make mattermost plugin compliant with JCasC

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/MattermostNotifier.java
+++ b/src/main/java/jenkins/plugins/mattermost/MattermostNotifier.java
@@ -338,18 +338,38 @@ public class MattermostNotifier extends Notifier {
 			load();
 		}
 
+		@DataBoundSetter
+		public void setEndpoint(String endpoint) {
+			this.endpoint = endpoint;
+		}
+		
 		public String getEndpoint() {
 			return endpoint;
 		}
 
+		@DataBoundSetter
+		public void setRoom(String room) {
+			this.room = room;
+		}
+		
 		public String getRoom() {
 			return room;
 		}
 
+		@DataBoundSetter
+		public void setIcon(String icon) {
+			this.icon = icon;
+		}
+		
 		public String getIcon() {
 			return icon;
 		}
 
+		@DataBoundSetter
+		public void setBuildServerUrl(String buildServerUrl) {
+			this.buildServerUrl = buildServerUrl;
+		}
+		
 		public String getBuildServerUrl() {
 			if (buildServerUrl == null || buildServerUrl.equals("")) {
 				JenkinsLocationConfiguration jenkinsConfig = new JenkinsLocationConfiguration();
@@ -395,21 +415,10 @@ public class MattermostNotifier extends Notifier {
 		}
 
 		@Override
-		public boolean configure(StaplerRequest sr, JSONObject formData) throws FormException {
-			endpoint = sr.getParameter("mattermostEndpoint");
-			room = sr.getParameter("mattermostRoom");
-			icon = sr.getParameter("mattermostIcon");
-			buildServerUrl = sr.getParameter("mattermostBuildServerUrl");
-			sendAs = sr.getParameter("mattermostSendAs");
-			if (buildServerUrl == null || buildServerUrl.equals("")) {
-				JenkinsLocationConfiguration jenkinsConfig = new JenkinsLocationConfiguration();
-				buildServerUrl = jenkinsConfig.getUrl();
-			}
-			if (buildServerUrl != null && !buildServerUrl.endsWith("/")) {
-				buildServerUrl = buildServerUrl + "/";
-			}
+		public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+			req.bindJSON(this, json);
 			save();
-			return super.configure(sr, formData);
+			return true;
 		}
 
 		MattermostService getMattermostService(final String endpoint, final String room, final String icon) {

--- a/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/global.jelly
@@ -15,16 +15,16 @@
   -->
 <f:section title="Global Mattermost Notifier Settings" name="mattermost">
     <f:entry title="Endpoint" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostEndpoint.html">
-        <f:textbox field="endpoint" name="mattermostEndpoint" value="${descriptor.getEndpoint()}" />
+        <f:textbox field="endpoint" value="${descriptor.getEndpoint()}" />
     </f:entry>
     <f:entry title="Channel" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostRoom.html">
-        <f:textbox field="room" name="mattermostRoom" value="${descriptor.getRoom()}" />
+        <f:textbox field="room" value="${descriptor.getRoom()}" />
     </f:entry>
     <f:entry title="Icon to use" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostIcon.html">
-        <f:textbox field="icon" name="mattermostIcon" value="${descriptor.getIcon()}" />
+        <f:textbox field="icon" value="${descriptor.getIcon()}" />
     </f:entry>
     <f:entry title="Build Server URL" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostBuildServerUrl.html">
-        <f:textbox field="buildServerUrl" name="mattermostBuildServerUrl" value="${descriptor.getBuildServerUrl()}" />
+        <f:textbox field="buildServerUrl" value="${descriptor.getBuildServerUrl()}" />
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"


### PR DESCRIPTION
Introduced DataBoundSetters and modified configure method to `request.bindJSON` method

changes required to make mattermost plugin configurable via configuration as code plugin (https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/PLUGINS.md)

no test or changes in pom yet - should be done though, separate PR should happen