### PR TITLE
fixing JCasC compatibility

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/mattermost/ActiveNotifier.java
@@ -67,11 +67,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
 			}
 		}
 
-		String changes = getChanges(build, notifier.includeCustomAttachmentMessage());
+		String changes = getChanges(build, notifier.getIncludeCustomAttachmentMessage());
 		if (changes != null) {
 			notifyStart(build, changes);
 		} else {
-			notifyStart(build, getBuildStatusMessage(build, false, notifier.includeCustomAttachmentMessage()));
+			notifyStart(build, getBuildStatusMessage(build, false, notifier.getIncludeCustomAttachmentMessage()));
 		}
 	}
 
@@ -113,8 +113,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
 				|| (result == Result.SUCCESS && notifier.getNotifySuccess())
 				|| (result == Result.UNSTABLE && notifier.getNotifyUnstable())) {
 			String expandedCustomMessage = getExpandedCustomMessage(r);
-			getMattermost(r).publish(getBuildStatusMessage(r, notifier.includeTestSummary(),
-					notifier.includeCustomAttachmentMessage()), expandedCustomMessage, getBuildColor(r));
+			getMattermost(r).publish(getBuildStatusMessage(r, notifier.getIncludeTestSummary(),
+					notifier.getIncludeCustomAttachmentMessage()), expandedCustomMessage, getBuildColor(r));
 			if (notifier.getCommitInfoChoice().showAnything()) {
 				getMattermost(r).publish(getCommitList(r), expandedCustomMessage, getBuildColor(r));
 			}
@@ -224,7 +224,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
 	String getExpandedCustomMessage(AbstractBuild build) {
 		String result = "";
-		if(notifier.includeCustomMessage()) {
+		if(notifier.getIncludeCustomMessage()) {
 			String customMessage = notifier.getCustomMessage();
 			EnvVars envVars = new EnvVars();
 			try {

--- a/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/config.jelly
@@ -3,76 +3,71 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="Notify Build Start">
-        <f:checkbox name="mattermostStartNotification" value="true" checked="${instance.getStartNotification()}"/>
+        <f:checkbox field="startNotification" />
     </f:entry>
 
     <f:entry title="Notify Aborted">
-        <f:checkbox name="mattermostNotifyAborted" value="true" checked="${instance.getNotifyAborted()}"/>
+        <f:checkbox field="notifyAborted" />
     </f:entry>
 
     <f:entry title="Notify Failure">
-        <f:checkbox name="mattermostNotifyFailure" value="true" checked="${instance.getNotifyFailure()}"/>
+        <f:checkbox field="notifyFailure" />
     </f:entry>
 
     <f:entry title="Notify Not Built">
-        <f:checkbox name="mattermostNotifyNotBuilt" value="true" checked="${instance.getNotifyNotBuilt()}"/>
+        <f:checkbox field="notifyNotBuilt" />
     </f:entry>
 
     <f:entry title="Notify Success">
-        <f:checkbox name="mattermostNotifySuccess" value="true" checked="${instance.getNotifySuccess()}"/>
+        <f:checkbox field="notifySuccess" />
     </f:entry>
 
     <f:entry title="Notify Unstable">
-        <f:checkbox name="mattermostNotifyUnstable" value="true" checked="${instance.getNotifyUnstable()}"/>
+        <f:checkbox field="notifyUnstable" />
     </f:entry>
 
     <f:entry title="Notify Back To Normal">
-        <f:checkbox name="mattermostNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
+        <f:checkbox field="notifyBackToNormal" />
     </f:entry>
 
     <f:advanced>
         <f:entry title="Notify Repeated Failure">
-            <f:checkbox name="mattermostNotifyRepeatedFailure" value="true"
-                        checked="${instance.getNotifyRepeatedFailure()}"/>
+            <f:checkbox field="notifyRepeatedFailure" />
         </f:entry>
         <f:entry title="Include Test Summary">
-            <f:checkbox name="includeTestSummary" value="true" checked="${instance.includeTestSummary()}"/>
+            <f:checkbox field="includeTestSummary" />
         </f:entry>
 
-        <f:optionalBlock name="includeCustomAttachmentMessage" title="Include custom attachment message" checked="${instance.includeCustomAttachmentMessage()}">
-            <f:entry title="Custom Attachment Message" help="/plugin/mattermost/help-projectConfig-mattermostCustomAttachmentMessage.html">
-                <f:textarea name="mattermostCustomAttachmentMessage" value="${instance.getCustomAttachmentMessage()}"/>
+        <f:optionalBlock name="includeCustomAttachmentMessage" title="Include custom attachment message" inline="true" checked="${instance.customAttachmentMessage != null}">
+            <f:entry title="Custom Attachment Message" field="customAttachmentMessage" help="/plugin/mattermost/help-projectConfig-mattermostCustomAttachmentMessage.html">
+                <f:textarea />
             </f:entry>
         </f:optionalBlock>
 
-        <f:optionalBlock name="includeCustomMessage" title="Include custom message" checked="${instance.includeCustomMessage()}">
-            <f:entry title="Text" help="/plugin/mattermost/help-projectConfig-mattermostCustomMessage.html">
-                <f:textarea name="mattermostCustomMessage" value="${instance.getCustomMessage()}"/>
+        <f:optionalBlock name="includeCustomMessage" title="Include custom message" inline="true" checked="${instance.customMessage != null}">
+            <f:entry title="Custom Message" field="customMessage" help="/plugin/mattermost/help-projectConfig-mattermostCustomMessage.html">
+                <f:textarea />
             </f:entry>
         </f:optionalBlock>
 
-        <f:entry title="Notification message includes" description="What commit information to include into notification message">
-            <select class="setting-input" name="slackCommitInfoChoice">
-                <j:forEach var="i" items="${descriptor.COMMIT_INFO_CHOICES}">
-                    <f:option selected="${instance.getCommitInfoChoice()==i}">${i.getDisplayName()}</f:option>
-                </j:forEach>
-            </select>
+        <f:entry field="commitInfoChoice" title="Notification message includes"  description="What commit information to include into notification message">
+            <select />
         </f:entry>
 
         <f:entry title="Endpoint" help="/plugin/mattermost/help-projectConfig-mattermostEndpoint.html">
-            <f:textbox name="mattermostEndpoint" value="${instance.getEndpoint()}"/>
+            <f:textbox field="endpoint" />
         </f:entry>
 
         <f:entry title="Project Channel" help="/plugin/mattermost/help-projectConfig-mattermostRoom.html">
-            <f:textbox name="mattermostRoom" value="${instance.getRoom()}"/>
+            <f:textbox field="room" />
         </f:entry>
 
         <f:entry title="Icon to use" help="/plugin/mattermost/help-projectConfig-mattermostIcon.html">
-            <f:textbox name="mattermostIcon" value="${instance.getIcon()}"/>
+            <f:textbox field="icon" />
         </f:entry>
 
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="mattermostEndpoint,mattermostRoom,mattermostIcon"/>
+                method="testConnection" with="endpoint,room,icon"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/config.jelly
@@ -51,7 +51,7 @@
         </f:optionalBlock>
 
         <f:entry field="commitInfoChoice" title="Notification message includes"  description="What commit information to include into notification message">
-            <select />
+            <f:select />
         </f:entry>
 
         <f:entry title="Endpoint" help="/plugin/mattermost/help-projectConfig-mattermostEndpoint.html">

--- a/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/global.jelly
@@ -13,21 +13,21 @@
     tags they use. Views are always organized according to its owner class,
     so it should be straightforward to find them.
   -->
-<f:section title="Global Mattermost Notifier Settings" name="mattermost">
-    <f:entry title="Endpoint" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostEndpoint.html">
-        <f:textbox field="endpoint" value="${descriptor.getEndpoint()}" />
+<f:section title="Global Mattermost Notifier Settings">
+    <f:entry title="Endpoint" help="/plugin/mattermost/help-globalConfig-mattermostEndpoint.html">
+        <f:textbox field="endpoint" />
     </f:entry>
-    <f:entry title="Channel" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostRoom.html">
-        <f:textbox field="room" value="${descriptor.getRoom()}" />
+    <f:entry title="Channel" help="/plugin/mattermost/help-globalConfig-mattermostRoom.html">
+        <f:textbox field="room" />
     </f:entry>
-    <f:entry title="Icon to use" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostIcon.html">
-        <f:textbox field="icon" value="${descriptor.getIcon()}" />
+    <f:entry title="Icon to use" help="/plugin/mattermost/help-globalConfig-mattermostIcon.html">
+        <f:textbox  field="icon"/>
     </f:entry>
-    <f:entry title="Build Server URL" help="${rootURL}/plugin/mattermost/help-globalConfig-mattermostBuildServerUrl.html">
-        <f:textbox field="buildServerUrl" value="${descriptor.getBuildServerUrl()}" />
+    <f:entry title="Build Server URL" help="/plugin/mattermost/help-globalConfig-mattermostBuildServerUrl.html">
+        <f:textbox  field="buildServerUrl"/>
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="mattermostEndpoint,mattermostRoom,mattermostBuildServerUrl" />
+        method="testConnection" with="endpoint,room,buildServerUrl" />
   </f:section>
 </j:jelly>


### PR DESCRIPTION
As reported in https://github.com/kuleuven/jenkins-mattermost-plugin/issues/31 I broke the plugin.
After all the fix was a little bit more complicated and I used PR by @timja for slack plugin as an inspiration: https://github.com/jenkinsci/slack-plugin/pull/404

it seems you can configure global configuration both manually and with jcasc now
you can also manually configure what's in the job

What's missing

1. Can't fill `Notification message includes` choice with proper options
2. Haven't tested if it actually works with mattermost - I'm not using it and if anyone here can spare some time on verifying with that version that would be great, if not I'll try to do that later 
3. Haven't tested if it's working well with JobDSL (not sure if it could break but better safe than sorry)

So I'll continue my work to fix 1. But I wanted to share what I have so far, so anyone can contribute with some testing if you'd like

cc @jovandeginste 
