### PR TITLE
Escape 'some' mattermost markdown in job display name

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/mattermost/ActiveNotifier.java
@@ -338,9 +338,9 @@ public class ActiveNotifier implements FineGrainedNotifier {
 		}
 
 		private MessageBuilder startMessage() {
-			message.append(this.escape(build.getProject().getFullDisplayName()));
+			message.append(this.escapeDisplayName(build.getProject().getFullDisplayName()));
 			message.append(" - ");
-			message.append(this.escape(build.getDisplayName()));
+			message.append(this.escapeDisplayName(build.getDisplayName()));
 			message.append(" ");
 			return this;
 		}
@@ -416,6 +416,19 @@ public class ActiveNotifier implements FineGrainedNotifier {
 			string = string.replace(">", "&gt;");
 
 			return string;
+		}
+
+		public String escapeDisplayName(String displayName) {
+			// escape HTML
+			displayName = escape(displayName);
+
+			// escape mattermost markdown which _may_ occur in job display names
+			displayName = displayName.replace("~", "\\~");
+			displayName = displayName.replace("*", "\\*");
+			displayName = displayName.replace("_", "\\_");
+			displayName = displayName.replace("`", "\\`");
+
+			return displayName;
 		}
 
 		public String toString() {


### PR DESCRIPTION
Hi there,

on our Jenkin-CI we use some _fancy_ job-names which look like this `repo_-_develop`.

Because of the `_` mattermost interprets parts of the job name as markup which generates some weird build-notifications.

E.g. instead of 
> repo\_-\_develop - #123 :white_check_mark: Back to normal after 3 days 3hr [Open](http://10.10.3.5:8080/job/repo\_-\_develop/123/)

we are seeing something like this
![unnamed](https://user-images.githubusercontent.com/16318489/61967362-67731180-afd5-11e9-88f9-6c38f2cd8de5.png)

To cut a long story short: with this pull-request the job display name is escaped with the result that it is not falsely interpreted as markup (by mattermost)
