### PR TITLE
Plugin doc migration from wiki to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Mattermost plugin for Jenkins
 
-Based on a fork of the Slack plugin:
+This plugin allows users to send build notifications to a self-hosted
+[Mattermost](http://www.mattermost.org/) installation.
 
+It is based on a fork of the Slack plugin:
 https://github.com/jenkinsci/slack-plugin/
 
-Which was a fork of the HipChat plugin:
-
+The Slack plugin was a fork of the HipChat plugin:
 https://github.com/jlewallen/jenkins-hipchat-plugin
 
-Which was, in turn, a fork of the Campfire plugin.
+Which in turn, was a fork of the Campfire plugin.
 
-Includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) support as of version 2.0:
+It includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) support as of version 2.0:
 
 ```
 mattermostSend color: 'good', message: 'Message from Jenkins Pipeline', text: 'optional for @here mentions and searchable text'
@@ -18,14 +19,14 @@ mattermostSend color: 'good', message: 'Message from Jenkins Pipeline', text: 'o
 
 # Jenkins Instructions
 
-1. Set up a Mattermost server
-2. Configure an incoming webhook
+1. The first step is to set up a Mattermost server
+2. Then Configure an incoming webhook
 3. Install this plugin on your Jenkins server
 4. **Add it as a Post-build action** in your Jenkins job.
 
 # Developer instructions
 
-Install Maven and JDK.
+Make sure you have Maven and JDK installed.
 
 Run unit tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <version>3.1.2-SNAPSHOT</version>
   <name>Mattermost Notification Plugin</name>
   <description>A Build status publisher that notifies channels on a Mattermost server</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Mattermost+Plugin</url>
+  <url>https://plugins.jenkins.io/mattermost/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <version>3.1.2-SNAPSHOT</version>
   <name>Mattermost Notification Plugin</name>
   <description>A Build status publisher that notifies channels on a Mattermost server</description>
-  <url>https://plugins.jenkins.io/mattermost/</url>
+  <url>https://github.com/jenkinsci/mattermost-plugin</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
- Modified some content in the README.md file using https://github.com/jenkins-infra/plugins-wiki-docs/tree/master/mattermost
- Modified grammar to enhance readability.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
