### PR TITLE
Changed documentation URL to Github's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # release notes
 
+## 3.1.2
+Linked plugin documentation to https://github.com/jenkinsci/mattermost-plugin/README.md
+
+...
+
 ## 2.4.0
 
 If you split channel names purely on space, you should now add commas (`,`) or semicolons (`;`) now - spaces can now be used as part of the user name.

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <version>3.1.2-SNAPSHOT</version>
   <name>Mattermost Notification Plugin</name>
   <description>A Build status publisher that notifies channels on a Mattermost server</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Mattermost+Plugin</url>
+  <url>https://github.com/jenkinsci/mattermost-plugin</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Following guideline https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/, link plugin documentation https://plugins.jenkins.io/mattermost/ with existing README.md file. 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue